### PR TITLE
Remove duplicate line

### DIFF
--- a/crack-keepassfile.ps1
+++ b/crack-keepassfile.ps1
@@ -93,7 +93,6 @@ Function Load-KeePassBinarys{
            Write-Output "KeePass Binaries loaded from $path"
           }
             }
-                                                                                                                                                                                                                                                                                                                                                                                    function try-key($x){
  function try-key($x){
     $Key = new-object KeePassLib.Keys.CompositeKey
     $Key.AddUserKey((New-Object KeePassLib.Keys.KcpPassword($x)));


### PR DESCRIPTION
Lin 96 had on far right an unwanted copy of  
function try-key($x){
which would cause a Missing closing ‘}’ error.